### PR TITLE
뱃지가 없는 유저일 경우 발생하는 오류 수정

### DIFF
--- a/src/card.ts
+++ b/src/card.ts
@@ -24,7 +24,6 @@ class Card {
       rank,
       solved,
       class: classNumber,
-      badge: { url: badge_url },
       profile_image_url,
       exp,
       rating,


### PR DESCRIPTION
뱃지가 없는 유저일 경우 API에서 아래와 같이 badge object를 포함하지 않고 리턴됩니다.

```json
{
  "success": true,
  "result": {
    "user": [
      {
        "user_id": "kentakang",
        "bio": "",
        "profile_image_url": null,
        "solved": 173,
        "exp": 302483,
        "level": 9,
        "class": 1,
        "class_decoration": 0,
        "rating": 592,
        "rating_problems": 466,
        "rating_class": 25,
        "rating_solved_count": 101,
        "rating_vote_count": 0,
        "vote_count": 0,
        "badge_id": "",
        "rank": 9078,
        "is_rival": false,
        "is_reverse_rival": false,
        "organizations": [],
        "reverse_rival_count": 0,
        "background_image": {
          "background_id": 5,
          "url_light": "https://static.solved.ac/profile_bg/balloon_003/balloon_003.png",
          "url_dark": "https://static.solved.ac/profile_bg/balloon_003/balloon_003.png"
        }
      }
    ]
  }
}
```
하지만 src/card.ts 에서 데이터에 badge가 있는지 여부와 상관 없이 가져오도록 되어 있어 뱃지가 없는 유저들의 경우 500 에러가 발생하고 있었습니다.

코드 내에서 뱃지를 사용 중인 부분이 없어 badge를 유저 정보에서 가져오는 코드를 아예 제거했습니다.

