### PR TITLE
Node 의존성에 따른 import 형식 변경

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import CardBuilder from '../src/card';
-import { fetchUserInformation } from '../src/fetch';
+import CardBuilder from '../src/card/index.js';
+import { fetchUserInformation } from '../src/fetch/index.js';
 
 export default async (request: VercelRequest, response: VercelResponse) => {
   const handle = request.query.handle;

--- a/src/card/converters.ts
+++ b/src/card/converters.ts
@@ -1,4 +1,4 @@
-import { TierRank, TierDivision } from '../types';
+import { TierRank, TierDivision } from '../types/index.js';
 
 export const getTierString = (tier: number): string => {
   const tierRankList: TierRank[] = [

--- a/src/card/index.ts
+++ b/src/card/index.ts
@@ -1,10 +1,10 @@
-import classSvg from '../../assets/classSvg';
-import tierSvg from '../../assets/tierSvg';
-import { fetchImage } from '../fetch';
-import { UserInformation } from '../types';
-import { sanitizeString } from '../utils/sanitizer';
-import { getTierRank, getTierString } from './converters';
-import { getGlobalStyle, getMasterGradient } from './templates';
+import classSvg from '../../assets/classSvg.js';
+import tierSvg from '../../assets/tierSvg.js';
+import { fetchImage } from '../fetch/index.js';
+import { UserInformation } from '../types/index.js';
+import { sanitizeString } from '../utils/sanitizer.js';
+import { getTierRank, getTierString } from './converters.js';
+import { getGlobalStyle, getMasterGradient } from './templates.js';
 
 interface CardBuilderProps {
   width?: number;

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -1,5 +1,5 @@
 import { gotScraping } from 'got-scraping';
-import { UserInformation } from '../types';
+import { UserInformation } from '../types/index.js';
 
 export const fetchUserInformation = async (
   handle: string | string[]


### PR DESCRIPTION
## PR 개요
로컬 환경에서 solved.ac 카드가 정상적으로 렌더링되지만 vercel 배포 환경에서는 500 Error 발생.

의존성 업데이트(Node) 및 `got-scraping` (ESM 전용 패키지) 사용으로 인해 

(기존) CommonJs 모듈 / Vercel 배포환경에서 import 문을 토대로 디렉토리 내 `index` 파일을 찾던 방식에서
(변경) 브라우저에서 URL에 접근하듯 정확한 파일 확장자까지 표기해서 파일에 접근하는 방식으로 변경됐다.

로컬에서는 `"moduleResolution": "Bundler"` 설정으로 외부에서 생략된 경로를 보정해줬기 때문에 정상적으로 실행된 것 처럼 보였지만
Vercel 의 최신 빌드 환경에서는 ESM 런타임에서 개별적으로 import 문을 실행하며 500 Error 가 발생했다.

<br>

**따라서** 
→ Vercel 배포 환경에서도 정상적으로 실행될 수 있도록 import 형식에 확장자를 명시하도록 코드를 변경.

<br>

## import 경로에 확장자 명시
- 기존 디렉토리 형태로 작성됐던 import 문 형식에 확장자 `.js` 및 `index.js` 명시

<br>

<details>
<summary><b>개인 Vercel 배포 후, 테스트 결과 화면</b></summary><br>
<img width="1552" height="916" alt="스크린샷 2026-05-07 19 07 10" src="https://github.com/user-attachments/assets/88573463-1ef1-4f08-87b1-cb3eadd5097c" />
</details>

